### PR TITLE
[CI] Automatic deploy test application 

### DIFF
--- a/CI/deploy.sh
+++ b/CI/deploy.sh
@@ -3,7 +3,7 @@ jarFile=$(find ../target/ -name "*-spring-boot.jar")
 
 # Copy Unit & JAR
 scp -i ~/.ssh/id_rsa_student_mgmt_backend "sparky-spring-boot.service" elscha@147.172.178.30:~/.config/systemd/user
-scp -i ~/.ssh/id_rsa_student_mgmt_backend "${jarFile}" elscha@147.172.178.30:~/Sparky
+scp -i ~/.ssh/id_rsa_student_mgmt_backend "${jarFile}" elscha@147.172.178.30:~/Sparky/sparkyservice-spring-boot.jar
 
 # Update service
 ssh -i ~/.ssh/id_rsa_student_mgmt_backend elscha@147.172.178.30 'systemctl --user daemon-reload'

--- a/CI/sparky-spring-boot.service
+++ b/CI/sparky-spring-boot.service
@@ -3,7 +3,7 @@ Description=Sparky Service
 
 [Service]
 WorkingDirectory=/home/elscha/Sparky
-ExecStart=/usr/bin/java -cp sparkyservice-api-0.3.0-spring-boot.jar:application-release.properties org.springframework.boot.loader.JarLauncher
+ExecStart=/usr/bin/java -cp sparkyservice-spring-boot.jar:application-release.properties org.springframework.boot.loader.JarLauncher
 Type=simple
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
This removes the dependency of the systemd-service to the actual release version. 
With each release we must change the version number of inside the systemd unit to run the application. 

- This could a be an advantage if the want to regulate or control which version is  going to start on the live instance.
- This is a disadvantage when we always want the newest (stable) version running as live instance **automatically**. In that case, merge this pull request.

 @Elscha;  your decision